### PR TITLE
port: Port to 26.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,11 +68,15 @@ dependencies {
     }
 
     val cmVersion: String by project
-    implementation("me.fallenbreath:conditional-mixin:$cmVersion")
-    include("me.fallenbreath:conditional-mixin:$cmVersion")
+    implementation("me.fallenbreath:conditional-mixin-fabric:$cmVersion")
+    include("me.fallenbreath:conditional-mixin-fabric:$cmVersion")
 
     runtimeOnly("net.peanuuutz.tomlkt:tomlkt:0.3.7")
     runtimeOnly("blue.endless:jankson:1.2.3")
+}
+
+loom {
+    accessWidenerPath.set(file("src/main/resources/particle_core.accessWidener"))
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,22 +2,22 @@ kotlin.code.style = official
 org.gradle.jvmargs = -Xmx2G
 org.gradle.warning.mode = all
 # Check these on https://fabricmc.net/versions.html
-minecraftVersion=26.1
-loaderVersion =0.19.2
+minecraftVersion=26.2
+loaderVersion =0.19.3
 # Fabric API
-fabricVersion=0.145.1+26.1
-loomVersion = 1.16-SNAPSHOT
+fabricVersion=0.153.0+26.2
+loomVersion = 1.17-SNAPSHOT
 # Mod Properties
 modVersion = 0.3.2
 mavenGroup = fzzyhmstrs
 archivesBaseName = particle_core
 # Kotlin
-systemProp.kotlinVersion = 2.3.10
-fabricKotlinVersion = 1.13.9+kotlin.2.3.10
+systemProp.kotlinVersion = 2.4.0
+fabricKotlinVersion = 1.13.12+kotlin.2.4.0
 # Dependencies
-guavaVersion = 32.0.0-jre
+guavaVersion = 33.6.0-jre
 fzzyConfigVersion = 0.7.6
-cmVersion = 0.5.1
+cmVersion = 0.6.4
 # uploads
 mcVersions = 26.1,26.1.1,26.1.2
 uploadDebugMode = false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/fzzyhmstrs/particle_core/mixins/ParticleBrightnessCacheMixin.java
+++ b/src/main/java/me/fzzyhmstrs/particle_core/mixins/ParticleBrightnessCacheMixin.java
@@ -15,6 +15,7 @@ import net.minecraft.client.multiplayer.ClientLevel;
 import net.minecraft.client.particle.Particle;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
+import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.level.BlockAndLightGetter;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Final;
@@ -43,7 +44,7 @@ public class ParticleBrightnessCacheMixin implements CachedLightPreparer {
     @WrapOperation(method = "getLightCoords", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/LevelRenderer;getLightCoords(Lnet/minecraft/world/level/BlockAndLightGetter;Lnet/minecraft/core/BlockPos;)I"), require = 0)
     private int particle_core_getCachedBrightness(BlockAndLightGetter world, BlockPos pos, Operation<Integer> original) {
         if (particle_core_cachedLight == -1) {
-            particle_core_cachedLight = LevelRenderer.getLightCoords(world, pos);
+            particle_core_cachedLight = LightCoordsUtil.getLightCoords(world, pos);
         }
         return particle_core_cachedLight;
     }
@@ -57,6 +58,6 @@ public class ParticleBrightnessCacheMixin implements CachedLightPreparer {
 
     @Unique
     private int getLightmap(BlockAndLightGetter world, BlockState state, BlockPos blockPos) {
-        return LevelRenderer.getLightCoords(LevelRenderer.BrightnessGetter.DEFAULT, world, state, blockPos);
+        return LightCoordsUtil.getLightCoords(LightCoordsUtil.BrightnessGetter.DEFAULT, world, state, blockPos);
     }
 }

--- a/src/main/java/me/fzzyhmstrs/particle_core/mixins/ParticleEngineAsyncMixin.java
+++ b/src/main/java/me/fzzyhmstrs/particle_core/mixins/ParticleEngineAsyncMixin.java
@@ -108,7 +108,7 @@ public abstract class ParticleEngineAsyncMixin {
 	private TickResult.Results asyncTickParticles(ParticleGroup<? extends Particle> particleCollection) {
 		Consumer<Particle> tick = ((ParticleGroupAccessor)particleCollection)::callTickParticle;
 
-		List<TickResult> results = particleCollection.getAll().parallelStream().map((p) -> tickParticleSafe(tick, p)).toList();
+		List<TickResult> results = particleCollection.particles.parallelStream().map((p) -> tickParticleSafe(tick, p)).toList();
 		return new TickResult.Results(results, particleCollection);
 	}
 
@@ -155,11 +155,11 @@ public abstract class ParticleEngineAsyncMixin {
 				((ParticleGroupAccessor)result.originalCollection()).callTickParticle(tr.particle());
 			}
 		}
-		if (i > (result.originalCollection().getAll().size() * 2 / 3)) {
+		if (i > (result.originalCollection().particles.size() * 2 / 3)) {
 			PcConfig.INSTANCE.getLogger().error("Asynchronous particle ticking encountered issues with over 2/3 of particles; disabling");
 			PcConfig.INSTANCE.getImpl().getAsynchronousTicking().validateAndSet(false);
 		}
-		Iterator<? extends Particle> iterator = result.originalCollection().getAll().iterator();
+		Iterator<? extends Particle> iterator = result.originalCollection().particles.iterator();
 		while (iterator.hasNext()) {
 			Particle particle = iterator.next();
 			if (particle.isAlive()) continue;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,10 +28,11 @@
   "mixins": [
     "particle_core.mixins.json"
   ],
+  "accessWidener": "particle_core.accessWidener",
   "depends": {
     "fabricloader": ">=${loaderVersion}",
     "fabric-language-kotlin": ">=${fabricKotlinVersion}",
-    "minecraft": ">=26.1",
+    "minecraft": ">=26.2",
     "fzzy_config": ">=${fzzyConfigVersion}"
   },
   "custom": {

--- a/src/main/resources/particle_core.accessWidener
+++ b/src/main/resources/particle_core.accessWidener
@@ -1,0 +1,3 @@
+accessWidener v2 official
+
+accessible field net/minecraft/client/particle/ParticleGroup particles Ljava/util/Queue;


### PR DESCRIPTION
Closes https://github.com/fzzyhmstrs/pc/issues/57 and https://github.com/fzzyhmstrs/pc/issues/58

Had to add an access widener since the `getAll` method was removed, so now it just access `particles` directly